### PR TITLE
Fix tmux navigation with Neovim

### DIFF
--- a/config/nvim/lua/plugins/tmux-navigator.lua
+++ b/config/nvim/lua/plugins/tmux-navigator.lua
@@ -1,0 +1,6 @@
+return {
+  {
+    "christoomey/vim-tmux-navigator",
+    lazy = false,
+  },
+}


### PR DESCRIPTION
## Summary
- add `vim-tmux-navigator` plugin so `<C-h/j/k/l>` work inside tmux

## Testing
- `nix flake show` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685451e01a308330b119d8e96b0ad80a