### PR TITLE
feat: support linux home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Dotfiles for Multiple MacBooks
+# Dotfiles for Multiple Machines
 
-This repository contains configurations for 3 different MacBooks:
+This repository contains configurations for several machines:
 - Home M4 MacBook
 - Home Intel MacBook
 - Work M1 MacBook
+- `srv722852` (Home x86_64 Linux)
 
 ## Structure
 
@@ -38,7 +39,7 @@ Run the installation script:
 
 The script will:
 1. Detect your machine type (hostname and architecture)
-2. Install necessary dependencies (nix, nix-darwin, homebrew)
+2. Install necessary dependencies (nix, plus nix-darwin and Homebrew on macOS or home-manager on Linux)
 3. Apply the appropriate configuration
 4. Automatically select the correct home-manager configuration based on machine context
 
@@ -86,10 +87,14 @@ This structure eliminates duplication in several ways:
 If automatic detection doesn't work, you can manually apply a configuration:
 
 ```bash
+# macOS
 darwin-rebuild switch --flake ~/dotfiles#[configuration-name]
+
+# Linux
+home-manager switch --flake ~/dotfiles#srv722852
 ```
 
-Where `[configuration-name]` is one of:
+Where `[configuration-name]` for macOS is one of:
 - `cortex` (Home M4 MacBook)
 - `malv2` (Home Intel MacBook)
 - `zthieme34911` (Work M1 MacBook)

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -3,7 +3,7 @@
 
 let
   username = "zach";
-  homeDirectory = "/Users/${username}";
+  homeDirectory = if pkgs.stdenv.isDarwin then "/Users/${username}" else "/home/${username}";
 in
 {
   # Import the base configuration with our username and home directory

--- a/home-manager/work.nix
+++ b/home-manager/work.nix
@@ -3,7 +3,7 @@
 
 let
   username = "zthieme";
-  homeDirectory = "/Users/${username}";
+  homeDirectory = if pkgs.stdenv.isDarwin then "/Users/${username}" else "/home/${username}";
 in
 {
   # Import the base configuration with our username and home directory

--- a/install.sh
+++ b/install.sh
@@ -5,56 +5,81 @@
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SCRIPT_DIR"
 
-# Determine the hostname and architecture
+# Determine the hostname, architecture, and operating system
 HOSTNAME=$(hostname)
 ARCHITECTURE=$(uname -m)
+OS=$(uname -s)
 
-# Determine configuration name
-if [[ "$HOSTNAME" == "zthieme"* ]]; then
-  CONFIG_NAME="zthieme34911"
-elif [[ "$ARCHITECTURE" == "arm64" ]]; then
-  CONFIG_NAME="cortex"
+if [[ "$OS" == "Darwin" ]]; then
+  # Determine configuration name for macOS
+  if [[ "$HOSTNAME" == "zthieme"* ]]; then
+    CONFIG_NAME="zthieme34911"
+  elif [[ "$ARCHITECTURE" == "arm64" ]]; then
+    CONFIG_NAME="cortex"
+  else
+    CONFIG_NAME="malv2"
+  fi
+
+  # Export for nix detection
+  export HOSTNAME
+  export NIX_SYSTEM=$([ "$ARCHITECTURE" == "arm64" ] && echo "aarch64-darwin" || echo "x86_64-darwin")
+
+  echo "=== Dotfiles Installation ==="
+  echo "Detected:"
+  echo "  Host: $HOSTNAME"
+  echo "  Architecture: $ARCHITECTURE"
+  echo "  System: $NIX_SYSTEM"
+  echo "  Configuration: $CONFIG_NAME"
+
+  # Create screenshots directory if it doesn't exist
+  mkdir -p ~/Pictures/screenshots/
+
+  # Apply the configuration
+  echo "Applying nix-darwin configuration..."
+  echo "Running: darwin-rebuild switch --flake $SCRIPT_DIR#$CONFIG_NAME"
+  sudo darwin-rebuild switch --flake "$SCRIPT_DIR#$CONFIG_NAME"
+
+  # Install doom-emacs if not already installed
+  if ! command -v "$HOME/.config/emacs/bin/doom" &>/dev/null; then
+    echo "Installing Doom Emacs..."
+    git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
+    ~/.config/emacs/bin/doom install
+  fi
+
+  # Install homebrew if not already installed
+  if ! command -v brew &>/dev/null; then
+    echo "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
+
 else
-  CONFIG_NAME="malv2"
-fi
+  # Linux setup using Home Manager
+  CONFIG_NAME="srv722852"
+  export HOSTNAME
+  export NIX_SYSTEM="x86_64-linux"
 
-# Export for nix detection
-export HOSTNAME
-export NIX_SYSTEM=$([ "$ARCHITECTURE" == "arm64" ] && echo "aarch64-darwin" || echo "x86_64-darwin")
+  echo "=== Dotfiles Installation ==="
+  echo "Detected:"
+  echo "  Host: $HOSTNAME"
+  echo "  Architecture: $ARCHITECTURE"
+  echo "  System: $NIX_SYSTEM"
+  echo "  Configuration: $CONFIG_NAME"
 
-echo "=== Dotfiles Installation ==="
-echo "Detected:"
-echo "  Host: $HOSTNAME"
-echo "  Architecture: $ARCHITECTURE"
-echo "  System: $NIX_SYSTEM"
-echo "  Configuration: $CONFIG_NAME"
+  mkdir -p ~/Pictures/screenshots/
 
-# Create screenshots directory if it doesn't exist
-mkdir -p ~/Pictures/screenshots/
+  if ! command -v home-manager &>/dev/null; then
+    echo "home-manager not found; installing..."
+    nix profile install nixpkgs#home-manager
+  fi
 
-# Install nix-darwin if not already installed
-# if ! command -v darwin-rebuild &>/dev/null; then
-#   echo "Installing nix-darwin..."
-#   nix-build https://github.com/LnL7/nix-darwin/archive/master.tar.gz -A installer
-#   ./result/bin/darwin-installer
-# fi
+  echo "Applying Home Manager configuration..."
+  home-manager switch --flake "$SCRIPT_DIR#$CONFIG_NAME"
 
-# Apply the configuration
-echo "Applying nix-darwin configuration..."
-echo "Running: darwin-rebuild switch --flake $SCRIPT_DIR#$CONFIG_NAME"
-sudo darwin-rebuild switch --flake "$SCRIPT_DIR#$CONFIG_NAME"
-
-# Install doom-emacs if not already installed
-if ! command -v "$HOME/.config/emacs/bin/doom" &>/dev/null; then
-  echo "Installing Doom Emacs..."
-  git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
-  ~/.config/emacs/bin/doom install
-fi
-
-# Install homebrew if not already installed
-if ! command -v brew &>/dev/null; then
-  echo "Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if ! command -v "$HOME/.config/emacs/bin/doom" &>/dev/null; then
+    echo "Installing Doom Emacs..."
+    git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
+    ~/.config/emacs/bin/doom install
+  fi
 fi
 
 echo "Installation complete!"


### PR DESCRIPTION
## Summary
- add srv722852 x86_64-linux host and homeConfigurations output
- make home-manager modules cross-platform
- handle Linux in install script and docs

## Testing
- `nix flake check` *(failed: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68c0700cb4c08330811d43d125610bd2