### PR TITLE
Refactor Nix configs with centralized base and overrides

### DIFF
--- a/base/default.nix
+++ b/base/default.nix
@@ -6,6 +6,9 @@
   ...
 }:
 
+let
+  commonPackages = import ../packages/common.nix { inherit pkgs; };
+in
 {
   # Accept arguments for user-specific settings with defaults
   options = {
@@ -32,91 +35,9 @@
 
   config = {
     # Common system packages for all machines
-    environment.systemPackages = with pkgs; [
-      bat
-      btop
-      carapace
-      curl
-      emacs
-      eza
-      fd
-      fish
-      fzf
-      gh
-      git
-      go
-      gotools
-      jq
-      jujutsu
-      mosh
-      neovim
-      nixfmt-rfc-style
-      nodejs_24
-      pandoc
-      python3
-      python312Packages.pdf2docx
-      ripgrep
-      rustup
-      tmux
-      tree
-      typst
-      vim
-      wget
-      yazi
-      zoxide
-      zsh
-    ];
+    environment.systemPackages = commonPackages;
 
-    # Common homebrew configuration
-    homebrew = {
-      enable = true;
-      taps = [
-        "FelixKratz/formulae"
-      ];
-      brews = [
-        "FelixKratz/formulae/borders"
-        "spotify_player"
-      ];
-      casks = [
-        "balenaetcher"
-        "bartender"
-        "dropbox"
-        "ghostty"
-        "homerow"
-        "logi-options+"
-        "nikitabobko/tap/aerospace"
-        "spotify"
-        "zed"
-      ];
-    };
-
-    # Common macOS system defaults
-    system.defaults = {
-      dock.autohide = true;
-      dock.expose-group-apps = true;
-      dock.expose-animation-duration = 0.1;
-      dock.mru-spaces = false;
-      finder.AppleShowAllExtensions = true;
-      finder.FXPreferredViewStyle = "clmv";
-      finder.ShowPathbar = true;
-      NSGlobalDomain.NSWindowShouldDragOnGesture = true;
-      screencapture.location = "~/Pictures/screenshots";
-      screensaver.askForPasswordDelay = 10;
-      spaces.spans-displays = true;
-    };
-
-    # Common keyboard settings
-    system.keyboard = {
-      enableKeyMapping = true;
-      remapCapsLockToEscape = true;
-    };
-
-    # Enable Touch ID for sudo
-    security.pam.services.sudo_local.touchIdAuth = true;
-
-    # Enable zsh
-    programs.zsh.enable = true;
-
+    
     # Set primary user based on configuration
     system.primaryUser = config.local.username;
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,10 @@
           modules = [
             # Base system configuration
             ./base/default.nix
-            
+
+            # OS-specific overrides
+            ./overlays/os/darwin.nix
+
             # Architecture and context overlays
             archModule
             contextSystemModule

--- a/home-manager/base.nix
+++ b/home-manager/base.nix
@@ -7,6 +7,9 @@
   ...
 }:
 
+let
+  commonPackages = import ../packages/common.nix { inherit pkgs; };
+in
 {
   home.username = username;
   home.homeDirectory = homeDirectory;
@@ -210,10 +213,12 @@
     nix-direnv.enable = true;
   };
 
-  home.packages = with pkgs; [
-    oh-my-posh
-    zsh-autosuggestions
-    zsh-syntax-highlighting
-    zsh-vi-mode
-  ];
+  home.packages =
+    commonPackages
+    ++ (with pkgs; [
+      oh-my-posh
+      zsh-autosuggestions
+      zsh-syntax-highlighting
+      zsh-vi-mode
+    ]);
 }

--- a/overlays/os/darwin.nix
+++ b/overlays/os/darwin.nix
@@ -1,0 +1,53 @@
+# macOS-specific system configuration
+{ pkgs, ... }:
+{
+  # Homebrew packages and casks
+  homebrew = {
+    enable = true;
+    taps = [
+      "FelixKratz/formulae"
+    ];
+    brews = [
+      "FelixKratz/formulae/borders"
+      "spotify_player"
+    ];
+    casks = [
+      "balenaetcher"
+      "bartender"
+      "dropbox"
+      "ghostty"
+      "homerow"
+      "logi-options+"
+      "nikitabobko/tap/aerospace"
+      "spotify"
+      "zed"
+    ];
+  };
+
+  # macOS defaults
+  system.defaults = {
+    dock.autohide = true;
+    dock.expose-group-apps = true;
+    dock.expose-animation-duration = 0.1;
+    dock.mru-spaces = false;
+    finder.AppleShowAllExtensions = true;
+    finder.FXPreferredViewStyle = "clmv";
+    finder.ShowPathbar = true;
+    NSGlobalDomain.NSWindowShouldDragOnGesture = true;
+    screencapture.location = "~/Pictures/screenshots";
+    screensaver.askForPasswordDelay = 10;
+    spaces.spans-displays = true;
+  };
+
+  # Keyboard settings
+  system.keyboard = {
+    enableKeyMapping = true;
+    remapCapsLockToEscape = true;
+  };
+
+  # Enable Touch ID for sudo
+  security.pam.services.sudo_local.touchIdAuth = true;
+
+  # Enable zsh as a system shell
+  programs.zsh.enable = true;
+}

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -1,0 +1,35 @@
+{ pkgs }:
+with pkgs; [
+  bat
+  btop
+  carapace
+  curl
+  emacs
+  eza
+  fd
+  fish
+  fzf
+  gh
+  git
+  go
+  gotools
+  jq
+  jujutsu
+  mosh
+  neovim
+  nixfmt-rfc-style
+  nodejs_24
+  pandoc
+  python3
+  python312Packages.pdf2docx
+  ripgrep
+  rustup
+  tmux
+  tree
+  typst
+  vim
+  wget
+  yazi
+  zoxide
+  zsh
+]


### PR DESCRIPTION
## Summary
- centralize shared package list for terminal tools
- split macOS-specific system config into dedicated module
- wire new OS override into flake and home-manager base

## Testing
- `nix fmt` *(fails: command not found)*
- `apt-get update && apt-get install -y nix` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c094c7ab088330a07c9004000ae562