### PR TITLE
Ensure Ghostty launches fish on startup

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,3 @@
+# Ensure Ghostty launches fish for all environments managed by Home Manager
+command = fish
+command-arg = --login


### PR DESCRIPTION
## Summary
- configure the shared Ghostty profile to run fish as a login shell so every host launches it by default

## Testing
- nix flake check *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_69040d860afc8330bcef3e09db85ab92